### PR TITLE
Cr/feature/log when skipping delegated methods

### DIFF
--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
@@ -119,12 +119,23 @@ static NSString *const kGCTableViewMapIndexKey = @"indexKey";
 #pragma mark selector response handling
 
 - (BOOL)allChildrenRespondToSelector:(SEL)aSelector {
+  BOOL allChildrenRespond = YES;
+  BOOL someChildrenRespond = NO;
+  
   for (id<UITableViewDelegate> childDelegate in self.childDataSources) {
     if (![childDelegate respondsToSelector:aSelector]) {
-      return NO;
+      allChildrenRespond = NO;
+    }
+    else {
+      someChildrenRespond = YES;
     }
   }
-  return YES;
+  
+  if (someChildrenRespond && !allChildrenRespond) {
+    NSLog(@"Warning: not all childDataSources implement %@ so it will be ignored.", NSStringFromSelector(aSelector));
+  }
+  
+  return allChildrenRespond;
 }
 
 - (BOOL)respondsToSelector:(SEL)aSelector {


### PR DESCRIPTION
We ran into some confusion using this because (though the reason behind it makes sense) it is not obvious that certain delegate methods will be skipped unless all children implement them. Adding a logging statement both warns new users of this library that it is a requirement to implement these methods for all children, and also (as in my case) is a useful tool when refactoring to make sure all the bases are covered.

Also I included the Kiwi cocoapods upgrade because the tests passed, but just let me know if you want a new clean PR without that.
