### PR TITLE
add 'afterDataSource' and removeChildDataSource

### DIFF
--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.h
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.h
@@ -10,30 +10,45 @@
 
 /**
  Aggregating Data Source
- 
+
  @discussion
- Implementation of UITableViewDataSource which allows multiple child 
+ Implementation of UITableViewDataSource which allows multiple child
  UITableViewDataSource implementations to be composed together and presented
  to a UITableView as if they were a single data source.
- 
+
  Useful in situations where you want a single table view to present content
  from multiple sources and you want to keep the logic for those data sources
- separate. 
- 
+ separate.
+
  Wraps up the logic to dispatch a given protocol method call to the appropriate
  child datasource as well as offsetting passed/returned section indexes and
- aggregating results across child data source methods. 
+ aggregating results across child data source methods.
  **/
 @interface GCMAggregatingTableViewDataSource : NSObject <UITableViewDataSource, UITableViewDelegate>
 
 /**
  Registers a given UITableViewDataSource as a child data source.
- 
+
  The order in which child data sources affects the order in which their content
  is presented.
- 
+
  @param childDataSource The child datasource to be registered
  **/
 - (void) addChildDataSource:(id<UITableViewDataSource, UITableViewDelegate>)childDataSource;
+
+/**
+ Registers a given UITableViewDataSource as a child data source, inserting it after the given dataSource.
+
+
+ @param childDataSource The child datasource to be registered
+ **/
+- (void)addChildDataSource:(id<UITableViewDataSource>)childDataSource afterDataSource:(id<UITableViewDataSource>)precedingDataSource;
+
+/**
+ Removes a given UITableViewDataSource as a child data source, if it has been registered.
+
+ @param childDataSource The child datasource to be removed
+ **/
+- (void) removeChildDataSource:(id<UITableViewDataSource, UITableViewDelegate>)childDataSource;
 
 @end

--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
@@ -57,12 +57,25 @@ static NSString *const kGCTableViewMapIndexKey = @"indexKey";
   [self.childDataSources addObject:childDataSource];
 }
 
+- (void)addChildDataSource:(id<UITableViewDataSource>)childDataSource afterDataSource:(id<UITableViewDataSource>)precedingDataSource{
+  if ([self.childDataSources containsObject:precedingDataSource]) {
+    NSInteger index = [self.childDataSources indexOfObject:precedingDataSource];
+    [self.childDataSources insertObject:childDataSource atIndex:index + 1];
+  }
+}
+
+- (void)removeChildDataSource:(id<UITableViewDataSource>)childDataSource {
+  if ([self.childDataSources containsObject:childDataSource]) {
+    [self.childDataSources removeObject:childDataSource];
+  }
+}
+
 #pragma mark child datasource offset helpers
 
 // TODO: Can other offset helper methods use this on this?
 - (void)withDataSourcesForTableView:(UITableView *)tableView
-                     performBlock:(void (^)(UITableView *wrappedTableView,
-                                          id<UITableViewDataSource> childDataSource))block {
+                       performBlock:(void (^)(UITableView *wrappedTableView,
+                                              id<UITableViewDataSource> childDataSource))block {
   NSInteger offset = 0;
   for (id<UITableViewDataSource> childDataSource in self.childDataSources) {
     block([self wrapTableView:tableView forOffset:offset], childDataSource);
@@ -109,11 +122,11 @@ static NSString *const kGCTableViewMapIndexKey = @"indexKey";
                              performBlock:^id(UITableView *wrappedTableView,
                                               id<UITableViewDataSource> childDataSource,
                                               NSInteger relativeSection) {
-    return block(wrappedTableView,
-                 childDataSource,
-                 [NSIndexPath indexPathForItem:indexPath.
-                  item inSection:relativeSection]);
-  }];
+                               return block(wrappedTableView,
+                                            childDataSource,
+                                            [NSIndexPath indexPathForItem:indexPath.
+                                             item inSection:relativeSection]);
+                             }];
 }
 
 #pragma mark selector response handling
@@ -148,7 +161,7 @@ static NSString *const kGCTableViewMapIndexKey = @"indexKey";
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   return [self withDataSourceForTableView:tableView
-                                  indexPath:indexPath
+                                indexPath:indexPath
                              performBlock:^id(UITableView *wrappedTableView,
                                               id<UITableViewDataSource> childDataSource,
                                               NSIndexPath *relativeIndexPath) {

--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSource.m
@@ -58,16 +58,13 @@ static NSString *const kGCTableViewMapIndexKey = @"indexKey";
 }
 
 - (void)addChildDataSource:(id<UITableViewDataSource>)childDataSource afterDataSource:(id<UITableViewDataSource>)precedingDataSource{
-  if ([self.childDataSources containsObject:precedingDataSource]) {
-    NSInteger index = [self.childDataSources indexOfObject:precedingDataSource];
-    [self.childDataSources insertObject:childDataSource atIndex:index + 1];
-  }
+  NSInteger index = [self.childDataSources indexOfObject:precedingDataSource];
+  NSAssert(index != NSNotFound, @"precedingDataSource object not found in AggregatingDataSource");
+  [self.childDataSources insertObject:childDataSource atIndex:index + 1];
 }
 
 - (void)removeChildDataSource:(id<UITableViewDataSource>)childDataSource {
-  if ([self.childDataSources containsObject:childDataSource]) {
-    [self.childDataSources removeObject:childDataSource];
-  }
+  [self.childDataSources removeObject:childDataSource];
 }
 
 #pragma mark child datasource offset helpers

--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSourceTests/GCMAggregatingTableViewDataSourceTests.m
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSourceTests/GCMAggregatingTableViewDataSourceTests.m
@@ -310,6 +310,45 @@ describe(@"GCMAggregatingTableViewDataSource", ^{
       });
     });
 
+    context(@"and one datasource removed", ^{
+      beforeEach(^{
+        [aggregatingDataSource removeChildDataSource:childDataSourceB];
+      });
+      context(@"tableView:numberOfRowsInSection:", ^{
+        it(@"forwards to the first child", ^{
+          [[childDataSourceObjA should] receive:@selector(tableView:numberOfRowsInSection:)
+                                      andReturn:theValue(5)
+                                  withArguments:any(),theValue(1)];
+          [[theValue([aggregatingDataSource tableView:tableView
+                                numberOfRowsInSection:1]) should] equal:theValue(5)];
+        });
+        it(@"raises if an out of range section is provided", ^{
+          [[theBlock(^{
+            [aggregatingDataSource tableView:tableView numberOfRowsInSection:2];
+          }) should] raise];
+        });
+      });
+      context(@"tableView:cellForRowAtIndexPath:", ^{
+        it(@"forwards to the first child", ^{
+          UITableViewCell *cell = [UITableViewCell mock];
+          [[childDataSourceObjA should] receive:@selector(tableView:cellForRowAtIndexPath:)
+                                      andReturn:cell
+                                  withArguments:any(),[NSIndexPath indexPathForItem:2
+                                                                          inSection:1]];
+          [[[aggregatingDataSource tableView:tableView
+                       cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                 inSection:1]] should] equal:cell];
+        });
+        it(@"throws an exception if asked for a cell which is out of range", ^{
+          [[theBlock(^{
+            [aggregatingDataSource tableView:tableView
+                       cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                 inSection:2]];
+          }) should] raise];
+          });
+        });
+    });
+      
     context(@"and one datasource inserted into the middle", ^{
         __block id<UITableViewDataSourceAndDelegate> childDataSourceX;
         __block id childDataSourceObjX;

--- a/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSourceTests/GCMAggregatingTableViewDataSourceTests.m
+++ b/GCMAggregatingTableViewDataSource/GCMAggregatingTableViewDataSourceTests/GCMAggregatingTableViewDataSourceTests.m
@@ -310,7 +310,85 @@ describe(@"GCMAggregatingTableViewDataSource", ^{
       });
     });
 
-    
+    context(@"and one datasource inserted into the middle", ^{
+        __block id<UITableViewDataSourceAndDelegate> childDataSourceX;
+        __block id childDataSourceObjX;
+        beforeEach(^{
+            childDataSourceX = [[GCMinimalDataSource alloc] init];
+            childDataSourceObjX = childDataSourceX;
+            [aggregatingDataSource addChildDataSource:childDataSourceX afterDataSource: childDataSourceObjA];
+        });
+        it(@"does not respond to all-or-nothing selectors", ^{
+            [[aggregatingDataSource shouldNot] respondToSelector:@selector(tableView:heightForRowAtIndexPath:)];
+        });
+        context(@"tableView:numberOfRowsInSection:", ^{
+            it(@"forwards to the first child", ^{
+                [[childDataSourceObjA should] receive:@selector(tableView:numberOfRowsInSection:)
+                                            andReturn:theValue(5)
+                                        withArguments:any(),theValue(1)];
+                [[theValue([aggregatingDataSource tableView:tableView
+                                      numberOfRowsInSection:1]) should] equal:theValue(5)];
+            });
+            it(@"forwards calls to the second child", ^{
+                [[childDataSourceObjX should] receive:@selector(tableView:numberOfRowsInSection:)
+                                            andReturn:theValue(10)
+                                        withArguments:any(),theValue(0)];
+                [[theValue([aggregatingDataSource tableView:tableView
+                                      numberOfRowsInSection:2]) should] equal:theValue(10)];
+            });
+            it(@"forwards calls to the third child", ^{
+                [[childDataSourceObjB should] receive:@selector(tableView:numberOfRowsInSection:)
+                                            andReturn:theValue(5)
+                                        withArguments:any(),theValue(0)];
+                [[theValue([aggregatingDataSource tableView:tableView
+                                      numberOfRowsInSection:3]) should] equal:theValue(5)];
+            });
+            it(@"raises if an out of range section is provided", ^{
+                [[theBlock(^{
+                    [aggregatingDataSource tableView:tableView numberOfRowsInSection:6];
+                }) should] raise];
+            });
+        });
+        context(@"tableView:cellForRowAtIndexPath:", ^{
+            it(@"forwards to the first child", ^{
+                UITableViewCell *cell = [UITableViewCell mock];
+                [[childDataSourceObjA should] receive:@selector(tableView:cellForRowAtIndexPath:)
+                                            andReturn:cell
+                                        withArguments:any(),[NSIndexPath indexPathForItem:2
+                                                                                inSection:1]];
+                [[[aggregatingDataSource tableView:tableView
+                             cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                       inSection:1]] should] equal:cell];
+            });
+            it(@"forwards to the second child", ^{
+                UITableViewCell *cell = [UITableViewCell mock];
+                [[childDataSourceObjX should] receive:@selector(tableView:cellForRowAtIndexPath:)
+                                            andReturn:cell
+                                        withArguments:any(),[NSIndexPath indexPathForItem:2
+                                                                                inSection:0]];
+                [[[aggregatingDataSource tableView:tableView
+                             cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                       inSection:2]] should] equal:cell];
+            });
+            it(@"forwards to the third child", ^{
+                UITableViewCell *cell = [UITableViewCell mock];
+                [[childDataSourceObjB should] receive:@selector(tableView:cellForRowAtIndexPath:)
+                                            andReturn:cell
+                                        withArguments:any(),[NSIndexPath indexPathForItem:2
+                                                                                inSection:0]];
+                [[[aggregatingDataSource tableView:tableView
+                             cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                       inSection:3]] should] equal:cell];
+            });
+            it(@"throws an exception if asked for a cell which is out of range", ^{
+                [[theBlock(^{
+                    [aggregatingDataSource tableView:tableView
+                               cellForRowAtIndexPath:[NSIndexPath indexPathForItem:2
+                                                                         inSection:6]];
+                }) should] raise];
+            });
+        });
+    });
     context(@"and one datasource with only required methods implemented", ^{
       __block id<UITableViewDataSourceAndDelegate> childDataSourceC;
       __block id childDataSourceObjC;


### PR DESCRIPTION
@confucious I haven't added tests for `removeChildDataSource` yet.  Want to get your ok on this approach.  Basically, this enables us to add/remove a datasource when you toggle a form element.